### PR TITLE
Don't suggest unsafe running of the script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,24 @@ It does the following:
 
 ## Usage
 
+Download this script
+
 ```
-bash <(curl -sS https://raw.githubusercontent.com/nidkil/wasabi-other-linux-setup/master/setup.sh)
+curl -sS https://raw.githubusercontent.com/nidkil/wasabi-other-linux-setup/master/setup.sh > wasabi_setup.sh
+```
+
+Inspect the script to verify it isn't malicious.
+
+Run the script:
+
+```
+bash wasabi_setup.sh
+```
+
+You can remove the script after installation.
+
+```
+rm wasabi_setup.sh
 ```
 
 ## Run Wasabi Wallet


### PR DESCRIPTION
PGP verification is pointless if the script is downloaded from github
and then blindly executed. One might blindly execute wasabi instead.

This changes the documentation to recommend verifying the script before
running.